### PR TITLE
Gitlab ci import

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.next
+.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+include:
+  # you must have a repo named ci-templates under the same namespace
+  # of the project of your distro on the private Gitlab in order
+  # to run secret CI/CD jobs
+  - project: '$CI_PROJECT_NAMESPACE/ci-templates'
+    ref: main
+    file: 'wizard-ui.yml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# see https://nextjs.org/docs/deployment#docker-image and
+# https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
+FROM node:16-alpine AS deps
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /app
+
+COPY package.json yarn.lock* ./
+RUN yarn --frozen-lockfile
+
+FROM node:16-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN yarn build
+
+FROM node:16-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 5000
+
+ENV PORT 5000
+
+ENTRYPOINT ["node", "server.js"]
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   reactStrictMode: true,
   swcMinify: true,
 }


### PR DESCRIPTION
Distros baseadas neste projeto que estejam hospedadas no Gitlab, precisam de uma maneira de
customizar seus CI/CD. A forma que este patch propõe é via um grande e único include.

Assim o que seria o arquivo `.gitlab-ci.yml` deste projeto fica completamente a cargo de
cada diferente distribuição, que pode customizar suas pipelines para cada necessidade específica,
da forma que bem entender.

Faz parte deste patch também a inclusão de um arquivo Dockerfile para facilitar a vida de
distros que utilizem containers em seus deploys.

Conteúdo / mudanças:

- adiciona um .gitlab-ci.yml customizável para as distros
- copia Dockerfile e .dockerignore de outro projeto nextjs
- altera a config do next.config.js para usar o `output: 'standalone'` que o Dockerfile espera