### PR TITLE
feat(welcome): welcome screen using component lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,28 +60,18 @@ stateDiagram-v2
     }
 ```
 
-### Wizard API
+## Biblioteca de Componentes
 
-[Wizard API](https://github.com/jaxyendy/wizard-api) é o Backend (BFF) deste projeto, abaixo alguns
-fluxos que envolvem comunicação entre este projeto e seu backend.
+Este projeto, além de ser um site NextJS, é também uma biblioteca dos componentes usados por este
+site.
 
-#### Contratação
+A lista dos componentes exportados pode ser vista no arquivo `/lib/index.ts`.
 
-```mermaid
-sequenceDiagram
-    Wizard UI->>Wizard API: Dados de formulário
-    alt dados inválidos
-        Wizard API-->>Wizard UI: Erro
-    end
-    Wizard API->>Wizard UI: Resposta
-```
+Este pacote npm é exportado sem transpilação, portanto para utilizar estes componentes em
+um outro projeto NextJS recomendamos o uso do plugin
+[next-transpile-modules](https://github.com/martpie/next-transpile-modules) ou alguma outra
+técnica similar.
 
-#### Consulta
-
-```mermaid
-sequenceDiagram
-    Wizard UI->>Wizard API: Consulta Status
-    Wizard API->>Wizard UI: Status conhecido (cache)
-    Wizard API->>Wizard UI: Último status
-```
-
+Para ajudar com o teste e desenvolvimento de componentes em conjunto com outros projetos NextJS
+localmente, antes da publicação no registry npm, uma ferramenta como o
+[yalc](https://github.com/wclr/yalc) pode também ser útil.

--- a/components/Default/index.tsx
+++ b/components/Default/index.tsx
@@ -1,0 +1,22 @@
+import { Heading, Button, Link } from '@chakra-ui/react'
+
+export function DefaultHeadline({ title, subtitle }) {
+  return (
+    <>
+      <Heading as="h1" size="lg">
+        {title}
+      </Heading>
+      <Heading as="h2" size="md">
+        {subtitle}
+      </Heading>
+    </>
+  )
+}
+
+export function DefaultLink({ children, ...other }) {
+  return (
+    <Button as={Link} {...other}>
+      {children}
+    </Button>
+  )
+}

--- a/components/NextButton.tsx
+++ b/components/NextButton.tsx
@@ -1,0 +1,13 @@
+import { Flex } from '@chakra-ui/react'
+
+function NextButton({children, Link, ...other}) {
+  return (
+    <Flex my={'2.125rem'} justifyContent={'flex-end'}>
+      <Link {...other} size="lg">
+        {children}
+      </Link>
+    </Flex>
+  )
+}
+
+export default NextButton

--- a/components/Welcome/WelcomeContent.tsx
+++ b/components/Welcome/WelcomeContent.tsx
@@ -1,0 +1,14 @@
+import NextButton from '../../components/NextButton'
+
+function WelcomeContent({ newContractPath, t, Headline, Link }) {
+  return (
+    <>
+      <Headline title={t('title')} subtitle={t('subtitle')} />
+      <NextButton Link={Link} href={newContractPath}>
+        {t('contract')}
+      </NextButton>
+    </>
+  )
+}
+
+export default WelcomeContent

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,4 @@
+import WelcomeContent from '../components/Welcome/WelcomeContent.tsx'
+import NextButton from '../components/NextButton.tsx'
+
+export { WelcomeContent, NextButton }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
-  "name": "wizard-ui",
+  "name": "@jaxyendy/wizard-ui",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
+  "exports": "lib/index.ts",
+  "files" : [
+    "components",
+    "lib"
+  ],
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@jaxyendy/wizard-ui",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.0",
   "private": false,
   "exports": "lib/index.ts",
-  "files" : [
+  "files": [
     "components",
     "lib"
   ],

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,8 @@ import { useTranslations } from 'next-intl'
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import styles from '../styles/Home.module.css'
-import { Button } from '@chakra-ui/react'
+import { WelcomeContent } from '../lib'
+import { DefaultLink, DefaultHeadline } from '../components/Default'
 
 const Home: NextPage = () => {
   const t = useTranslations('wizard')
@@ -18,45 +19,12 @@ const Home: NextPage = () => {
       </Head>
 
       <main className={styles.main}>
-        <h1 className={styles.title}>
-          Welcome to <a href="https://nextjs.org">Next.js!</a>
-        </h1>
-
-        
-        <p className={styles.description}>
-          Get started by editing{' '}
-          <code className={styles.code}>pages/index.tsx</code>
-        </p>
-
-        <div className={styles.grid}>
-          <a href="https://nextjs.org/docs" className={styles.card}>
-            <h2>Documentation &rarr;</h2>
-            <p>Find in-depth information about Next.js features and API.</p>
-          </a>
-
-          <a href="https://nextjs.org/learn" className={styles.card}>
-            <h2>Learn &rarr;</h2>
-            <p>Learn about Next.js in an interactive course with quizzes!</p>
-          </a>
-
-          <a
-            href="https://github.com/vercel/next.js/tree/canary/examples"
-            className={styles.card}
-          >
-            <h2>Examples &rarr;</h2>
-            <p>Discover and deploy boilerplate example Next.js projects.</p>
-          </a>
-
-          <a
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            className={styles.card}
-          >
-            <h2>Deploy &rarr;</h2>
-            <p>
-              Instantly deploy your Next.js site to a public URL with Vercel.
-            </p>
-          </a>
-        </div>
+        <WelcomeContent
+          newContractPath="/new"
+          t={t}
+          Headline={DefaultHeadline}
+          Link={DefaultLink}
+        />
       </main>
 
       <footer className={styles.footer}></footer>


### PR DESCRIPTION
This patch turns this nextjs application into an importable lib of (untranspiled) components.

The first exported component is a react component with the contents of the welcome screen.

This patch also replaces the default Nextjs boilerplate home page with a welcome screen using this component.

Finally, it updates the README to state that the components can be used by other nextjs apps using the plugin `next-transpile-modules`.