### PR TITLE
Automate npm publish

### DIFF
--- a/.github/workflows/npm-publish-alpha.yml
+++ b/.github/workflows/npm-publish-alpha.yml
@@ -1,0 +1,25 @@
+name: Atualiza versão alpha no NPM
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  bump-publish-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@jaxyendy'
+      - run: |
+          git config --global user.name "NPM Bot"
+          git config --global user.email "nobody@mail.example.com"
+      - run: yarn version --prerelease --preid alpha
+      - run: yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: git push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaxyendy/wizard-ui",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "private": false,
   "exports": "lib/index.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaxyendy/wizard-ui",
-  "version": "0.1.1-alpha.2",
+  "version": "0.1.1-alpha.3",
   "private": false,
   "exports": "lib/index.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaxyendy/wizard-ui",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.1-alpha.1",
   "private": false,
   "exports": "lib/index.ts",
   "files": [


### PR DESCRIPTION
Este patch adiciona uma github action que atualiza a versao alpha do pacote e o publica na npm sempre que um novo commit entrar na branch main